### PR TITLE
bug fix #48: add range check to fixed type

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-05-19
+### Added
+
+- Added range check to FixedType
+
 ## [Unreleased] - 2023-05-07
 ### Changed
 

--- a/src/numbers/fixed_point/types.cairo
+++ b/src/numbers/fixed_point/types.cairo
@@ -67,6 +67,11 @@ trait Fixed {
 
 impl FixedImpl of Fixed {
     fn new(mag: u128, sign: bool) -> FixedType {
+        if sign == true {
+            assert(mag <= MAX_u128, 'fixed type: out of range');
+        } else {
+            assert(mag <= MAX_u128 - 1_u128 , 'fixed type: out of range');
+        }
         return FixedType { mag: mag, sign: sign };
     }
 

--- a/src/tests/operators/math/fixed_point_test.cairo
+++ b/src/tests/operators/math/fixed_point_test.cairo
@@ -106,34 +106,34 @@ fn test_ln() {
 #[test]
 #[available_gas(10000000)]
 fn test_log2() {
-    let a = Fixed::from_unscaled_felt(32);
-    assert(a.log2().into() == 335544129, 'invalid log2'); // 4.99999995767848
+    let a = Fixed::from_unscaled_felt(31);
+    assert(a.log2().into() == 332470374, 'invalid log2'); // 4.954194635152817
 }
 
 #[test]
 #[available_gas(10000000)]
 fn test_log10() {
-    let a = Fixed::from_unscaled_felt(100);
-    assert(a.log10().into() == 134217717, 'invalid log10'); // 1.9999999873985543
+    let a = Fixed::from_unscaled_felt(30);
+    assert(a.log10().into() == 99127896, 'invalid log10'); // 1.477120757102966
 }
 
 #[test]
 fn test_eq() {
-    let a = Fixed::from_unscaled_felt(42);
-    let b = Fixed::from_unscaled_felt(42);
+    let a = Fixed::from_unscaled_felt(25);
+    let b = Fixed::from_unscaled_felt(25);
     let c = a == b;
     assert(c == true, 'invalid result');
 }
 
 #[test]
 fn test_ne_() {
-    let a = Fixed::from_unscaled_felt(42);
-    let b = Fixed::from_unscaled_felt(42);
+    let a = Fixed::from_unscaled_felt(25);
+    let b = Fixed::from_unscaled_felt(25);
     let c = a != b;
     assert(c == false, 'invalid result');
 
-    let a = Fixed::from_unscaled_felt(42);
-    let b = Fixed::from_unscaled_felt(-42);
+    let a = Fixed::from_unscaled_felt(25);
+    let b = Fixed::from_unscaled_felt(-25);
     let c = a != b;
     assert(c == true, 'invalid result');
 }
@@ -233,20 +233,16 @@ fn test_div_() {
     let c = a / b;
     assert(c.into() == -26843545, 'invalid neg decimal'); // 0.4
 
-    let a = Fixed::from_unscaled_felt(-1000);
-    let b = Fixed::from_unscaled_felt(12500);
+    let a = Fixed::from_unscaled_felt(-1);
+    let b = Fixed::from_unscaled_felt(12);
     let c = a / b;
-    assert(c.into() == -5368709, 'invalid neg decimal'); // 0.08
+    assert(c.into() == -5592405, 'invalid neg decimal'); // 0.08333333333333333
 
-    let a = Fixed::from_unscaled_felt(-10);
-    let b = Fixed::from_unscaled_felt(123456789);
-    let c = a / b;
-    assert(c.into() == -5, 'invalid neg decimal'); // 8.100000073706917e-8
-
-    let a = Fixed::from_unscaled_felt(123456789);
+   
+    let a = Fixed::from_unscaled_felt(12);
     let b = Fixed::from_unscaled_felt(-10);
     let c = a / b;
-    assert(c.into() == -828504486287769, 'invalid neg decimal'); // -12345678.9
+    assert(c.into() == -80530636, 'invalid neg decimal'); // -1.2
 }
 
 #[test]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Bug fix: add range check to `FixedType`

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
 mark
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- There is no check that asserts that a FixedType magnitude is between the expected range of 0 - 2**31 - 1. This allows instantiation of FixedType objects with values outside the expected range.

Issue Number: #48 


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

 - The range of values that can be added to FixedType is now limited to values between 0 and 2 ** 31 - 1. If you try to create a fixed type with a value outside of this range, a panic will occur.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->