### PR TITLE
Relu threshold

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased] - 2023-05-20
+### Changed
+
+- Updated relu u32 function to have a threshold parameter
+- Updated relu test folder structure
+
 ## [Unreleased] - 2023-05-19
 ### Added
 

--- a/src/operators/nn/functional/relu/relu_u32.cairo
+++ b/src/operators/nn/functional/relu/relu_u32.cairo
@@ -33,10 +33,10 @@ fn relu_u32(z: @Tensor<u32>, threshold:u32 ) -> Tensor<u32> {
         };
 
         let current_index = *data.pop_front().unwrap();
-        if current_index >= threshold {
-            data_result.append(current_index);
-        } else {
+        if current_index < threshold {
             data_result.append(zero);
+        } else {
+            data_result.append(current_index);
         };
     };
 

--- a/src/operators/nn/functional/relu/relu_u32.cairo
+++ b/src/operators/nn/functional/relu/relu_u32.cairo
@@ -12,6 +12,7 @@ use onnx_cairo::utils::check_gas;
 ///
 /// # Arguments
 /// * `z` - A reference to an u32 tensor to which the ReLU function will be applied.
+/// * `threshold` - a u32 scalar that defines the threshold below which the Relu function returns 0.
 ///
 /// # Panics
 /// * Panics if gas limit is exceeded during execution.
@@ -19,7 +20,7 @@ use onnx_cairo::utils::check_gas;
 /// # Returns
 /// * A new u32 tensor with the same shape as the input tensor and the ReLU function
 ///   applied element-wise.
-fn relu_u32(z: @Tensor<u32>) -> Tensor<u32> {
+fn relu_u32(z: @Tensor<u32>, threshold:u32 ) -> Tensor<u32> {
     let mut data_result = ArrayTrait::<u32>::new();
     let mut data = *z.data;
 
@@ -32,7 +33,7 @@ fn relu_u32(z: @Tensor<u32>) -> Tensor<u32> {
         };
 
         let current_index = *data.pop_front().unwrap();
-        if current_index > zero {
+        if current_index >= threshold {
             data_result.append(current_index);
         } else {
             data_result.append(zero);

--- a/src/operators/nn/nn_u32.cairo
+++ b/src/operators/nn/nn_u32.cairo
@@ -11,6 +11,7 @@ mod NN {
     ///
     /// # Arguments
     /// * `z` - A reference to an u32 tensor to which the ReLU function will be applied.
+    /// * `threshold` - a u32 scalar that defines the threshold below which the Relu function returns 0.
     ///
     /// # Panics
     /// * Panics if gas limit is exceeded during execution.
@@ -18,8 +19,8 @@ mod NN {
     /// # Returns
     /// * A new u32 tensor with the same shape as the input tensor and the ReLU function
     ///   applied element-wise.
-    fn relu(tensor: @Tensor<u32>) -> Tensor<u32> {
-        relu_u32(tensor)
+    fn relu(tensor: @Tensor<u32>,threshold:u32) -> Tensor<u32> {
+        relu_u32(tensor,threshold)
     }
 
     /// Applies the leaky rectified linear unit (Leaky ReLU) activation function element-wise to a given u32 tensor.

--- a/src/tests/operators/nn/functional/relu.cairo
+++ b/src/tests/operators/nn/functional/relu.cairo
@@ -1,1 +1,2 @@
-mod relu_test;
+mod relu_i32_test;
+mod relu_u32_test;

--- a/src/tests/operators/nn/functional/relu/relu_i32_test.cairo
+++ b/src/tests/operators/nn/functional/relu/relu_i32_test.cairo
@@ -8,7 +8,7 @@ use onnx_cairo::operators::nn::nn_i32::NN;
 
 #[test]
 #[available_gas(2000000)]
-fn relu_test() {
+fn relu_i32_test() {
     let mut shape = ArrayTrait::<usize>::new();
     shape.append(2);
     shape.append(2);

--- a/src/tests/operators/nn/functional/relu/relu_u32_test.cairo
+++ b/src/tests/operators/nn/functional/relu/relu_u32_test.cairo
@@ -1,0 +1,43 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::implementations::impl_tensor_u32;
+use onnx_cairo::numbers::signed_integer::{integer_trait::IntegerTrait};
+use onnx_cairo::operators::nn::nn_u32::NN;
+
+#[test]
+#[available_gas(2000000)]
+fn relu_u32_test() {
+    let mut shape = ArrayTrait::<usize>::new();
+    shape.append(2);
+    shape.append(2);
+
+    let mut data = ArrayTrait::<u32>::new();
+    let val_1 = 1_u32;
+    let val_2 = 2_u32;
+    let val_3 = 3_u32;
+    let val_4 = 4_u32;
+
+    data.append(val_1);
+    data.append(val_2);
+    data.append(val_3);
+    data.append(val_4);
+
+    let mut tensor = TensorTrait::new(shape.span(), data.span());
+    let threshold = 3_u32;
+    let mut result = NN::relu(@tensor,threshold);
+
+    let data_0 = *result.data.at(0);
+    assert(data_0 == 0, 'result[0] == 0');
+
+    let data_1 = *result.data.at(1);
+    assert(data_1 == 0, 'result[1] == 0');
+
+    let data_2 = *result.data.at(2);
+    assert(data_2 == 3, 'result[2] == 3');
+
+    let data_3 = *result.data.at(3);
+    assert(data_3 == 4, 'result[3] == 4');
+    
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`relu_u32([array])=== [array]` for all u32 arrays

Issue Number: #54

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- A threshold parameter has been added to the relu u32 function to make sure that values below a certain threshold are mapped to zero 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->